### PR TITLE
 이용약관 및 개인정보 처리 방침 작업 PR

### DIFF
--- a/public/user/js/login/signupComplete.js
+++ b/public/user/js/login/signupComplete.js
@@ -1,18 +1,10 @@
 import { setupAjaxAuthInterceptor } from '../utils/auth-interceptor.js';
 
-$(document).ready(function () {
+$(document).ready(async function () {
     setupAjaxAuthInterceptor();
-    $.ajax({
-        type: "GET",
-        url: `${window.DOMAIN_URL}/users/basic-info`,
-        success: function (res) {
-            const userBasicInfo = res.data;
-            window.targetKcal = userBasicInfo.targetKcal;
-            window.name = userBasicInfo.name;
-            console.log(res);
-        },
-    });
-    showWelcomeMessage();
+
+    const data = await getUserBasicInfoData();
+    showWelcomeMessage(data);
     triggerConfettiEffect();
 
     $(".next-button.signup").on('click', function(){
@@ -20,16 +12,21 @@ $(document).ready(function () {
     });
 });
 
-function showWelcomeMessage() {
+function showWelcomeMessage(data) {
     $("#signupComplete").html(createWelcomeMessage());
-    setTimeout(showGoalMessage, 3000);
+    setTimeout(function () {
+        showGoalMessage(data);
+    }, 3000);
 }
 
-function showGoalMessage() {
-    let name = window.name;
+function showGoalMessage(data) {
+    let name = data.name;
     $(".welcome-text").fadeOut(1000, function () {
         $(this).replaceWith(createGoalMessage(name));
-        $(".goal-text-container").hide().fadeIn(2000, animateKcalCounter);
+        $(".goal-text-container").hide().fadeIn(2000, function () {
+            animateKcalCounter(data);
+        });
+        
     });
 }
 
@@ -46,8 +43,8 @@ const createGoalMessage = (name) => `
     </div>
 `;
 
-function animateKcalCounter() {
-    let targetValue = window.targetKcal, duration = 3000, startTime = performance.now();
+function animateKcalCounter(data) {
+    let targetValue = data.targetKcal, duration = 3000, startTime = performance.now();
 
     function easeOutExpo(t) {
         return t === 1 ? 1 : 1 - Math.pow(2, -15 * t);
@@ -137,4 +134,13 @@ function triggerConfettiEffect() {
         origin: { y: 0.55 },
         particleCount: 80
     });
+}
+
+async function getUserBasicInfoData() {
+    try {
+        const response = await $.ajax({ type: "GET", url: `${window.DOMAIN_URL}/users/basic-info`, contentType: "application/json"});
+        return response.data;
+    } catch (err) {
+        console.log(err);
+    }
 }

--- a/public/user/js/login/signupComplete.js
+++ b/public/user/js/login/signupComplete.js
@@ -8,6 +8,8 @@ $(document).ready(function () {
         success: function (res) {
             const userBasicInfo = res.data;
             window.targetKcal = userBasicInfo.targetKcal;
+            window.name = userBasicInfo.name;
+            console.log(res);
         },
     });
     showWelcomeMessage();
@@ -24,18 +26,19 @@ function showWelcomeMessage() {
 }
 
 function showGoalMessage() {
+    let name = window.name;
     $(".welcome-text").fadeOut(1000, function () {
-        $(this).replaceWith(createGoalMessage());
+        $(this).replaceWith(createGoalMessage(name));
         $(".goal-text-container").hide().fadeIn(2000, animateKcalCounter);
     });
 }
 
 const createWelcomeMessage = () => `<div class="welcome-text">환영합니다</div>`;
 
-const createGoalMessage = () => `
+const createGoalMessage = (name) => `
     <div class="goal-text-container">
         <div class="goal-text-wrapper">
-            <div class="goal-text-name">김예현</div>
+            <div class="goal-text-name">${name}</div>
             <div class="goal-text">님의 목표 달성을 위해선</div>
         </div>
         <div class="goal-kcal-wrapper"></div>

--- a/public/user/js/login/survey.js
+++ b/public/user/js/login/survey.js
@@ -5,21 +5,9 @@ import { initHeaderNav } from '/user/js/components/header-nav.js';
 import { setupAjaxAuthInterceptor } from '../utils/auth-interceptor.js';
 
 let currentPage = 1;
-let surveyData = {
-    email: '',
-    name: '',
-    birthYear: '',
-    birthMonth: '',
-    birthDay: '',
-    height: '',
-    weight: '',
-    gender: '',
-    goal: '',
-    activity: '',
-    isNextGym: ''
-};
-
 // 뒤로가기 이벤트 처리
+const surveyData = JSON.parse(localStorage.getItem('surveyData'));
+
 window.onpopstate = function (event) {
     if (event.state && event.state.page) {
         currentPage = event.state.page;
@@ -31,31 +19,6 @@ $(document).ready(function () {
     setupAjaxAuthInterceptor();
     const urlParams = new URLSearchParams(window.location.search);
     const savedPage = parseInt(urlParams.get('page')) || 1;
-    const token = urlParams.get("token");
-    const user = getPayloadFromToken(token);
-
-    // 생일이 "MM-DD" 형식이면 나눠서 넣기
-    const birthMonth = user.birthday?.split('-')[0] || '';
-    const birthDay = user.birthday?.split('-')[1] || '';
-
-    // surveyData 초기화
-    surveyData = {
-        email: user.email || '',
-        name: user.name || '',
-        birthYear: user.birthyear || '',
-        birthMonth,
-        birthDay,
-        height: user.height || '',
-        weight: user.weight || '',
-        gender: user.gender || '',
-        goal: '',
-        activity: '',
-        isNextGym: '',
-        signupProvider: user.signup_provider || '',
-        profileImageUrl: user.profile_image_url || '',
-    };
-
-    localStorage.setItem('surveyData', JSON.stringify(surveyData));
 
     currentPage = savedPage;
     initHeaderNav();

--- a/public/user/js/terms-privacy/terms-privacy.js
+++ b/public/user/js/terms-privacy/terms-privacy.js
@@ -1,20 +1,5 @@
 import { initHeaderNav } from '../components/header-nav.js';
 
-let surveyData = {
-    email: '',
-    name: '',
-    birthYear: '',
-    birthMonth: '',
-    birthDay: '',
-    height: '',
-    weight: '',
-    gender: '',
-    goal: '',
-    activity: '',
-    isNextGym: '',
-    termsAgreedAt:'',
-    privacyAgreedAt:''
-};
 
 $(document).ready(function () {
     initHeaderNav($('#terms'));
@@ -28,7 +13,7 @@ $(document).ready(function () {
     const birthDay = user.birthday?.split('-')[1] || '';
 
     // surveyData 초기화
-    surveyData = {
+    let surveyData = {
         email: user.email || '',
         name: user.name || '',
         birthYear: user.birthyear || '',
@@ -42,6 +27,8 @@ $(document).ready(function () {
         isNextGym: '',
         signupProvider: user.signup_provider || '',
         profileImageUrl: user.profile_image_url || '',
+        termsAgreedAt:'',
+        privacyAgreedAt:''
     };
 
     localStorage.setItem('surveyData', JSON.stringify(surveyData));
@@ -100,3 +87,23 @@ function getPayloadFromToken(token) {
         return null;
     }
 }
+
+$('#agreeButton').on('click', function () {
+    if ($(this).hasClass('disabled')) {
+        return; // 동의하지 않은 상태면 아무 것도 안함
+    }
+
+    // 현재 날짜/시간 ISO 포맷
+    const now = new Date().toISOString();
+
+    // surveyData 불러오기
+    let surveyData = JSON.parse(localStorage.getItem('surveyData') || '{}');
+
+    // 값 넣기
+    surveyData.termsAgreedAt = now;
+    surveyData.privacyAgreedAt = now;
+
+    // 다시 저장
+    localStorage.setItem('surveyData', JSON.stringify(surveyData));
+    window.location.href = '/survey'
+});

--- a/public/user/js/terms-privacy/terms-privacy.js
+++ b/public/user/js/terms-privacy/terms-privacy.js
@@ -1,12 +1,50 @@
 import { initHeaderNav } from '../components/header-nav.js';
 
-function renderTermsPrivacy() {
-    console.log("Test");
-}
+let surveyData = {
+    email: '',
+    name: '',
+    birthYear: '',
+    birthMonth: '',
+    birthDay: '',
+    height: '',
+    weight: '',
+    gender: '',
+    goal: '',
+    activity: '',
+    isNextGym: '',
+    termsAgreedAt:'',
+    privacyAgreedAt:''
+};
 
 $(document).ready(function () {
-    renderTermsPrivacy();
     initHeaderNav($('#terms'));
+    const urlParams = new URLSearchParams(window.location.search);
+    const token = urlParams.get("token");
+    const user = getPayloadFromToken(token);
+    console.log(user);
+    
+    // 생일이 "MM-DD" 형식이면 나눠서 넣기
+    const birthMonth = user.birthday?.split('-')[0] || '';
+    const birthDay = user.birthday?.split('-')[1] || '';
+
+    // surveyData 초기화
+    surveyData = {
+        email: user.email || '',
+        name: user.name || '',
+        birthYear: user.birthyear || '',
+        birthMonth,
+        birthDay,
+        height: user.height || '',
+        weight: user.weight || '',
+        gender: user.gender || '',
+        goal: '',
+        activity: '',
+        isNextGym: '',
+        signupProvider: user.signup_provider || '',
+        profileImageUrl: user.profile_image_url || '',
+    };
+
+    localStorage.setItem('surveyData', JSON.stringify(surveyData));
 
 
     function updateState() {
@@ -46,3 +84,19 @@ $(document).ready(function () {
         updateState();
     });
 });
+
+function getPayloadFromToken(token) {
+    try {
+        const base64Payload = token.split('.')[1].replace(/-/g, '+').replace(/_/g, '/');
+        const jsonPayload = decodeURIComponent(
+            atob(base64Payload)
+                .split('')
+                .map(c => '%' + ('00' + c.charCodeAt(0).toString(16)).slice(-2))
+                .join('')
+        );
+        return JSON.parse(jsonPayload);
+    } catch (e) {
+        console.error('JWT 파싱 에러:', e);
+        return null;
+    }
+}


### PR DESCRIPTION
### 작업 내용
- 회원가입 시 이용약관 동의 시각 서버 저장 로직 추가
- 개인정보 처리 방침 동의 로직 추가
- 기존 login-page -> survey 페이지 이동에서 login-page -> terms-privacy -> survey 페이지로 페이지 이동 순서 변경
- 미동의 시 회원가입 불가능 처리
- Terms/Privacy UI 체크 상태에 따른 로컬스토리지 처리 추가

### 목적
- 회원가입 절차에서 법적 요건 충족

### 기타
- 코드 스타일은 기존 프로젝트 컨벤션에 맞춤


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **신규 기능**
  * 회원가입 완료 시 실제 사용자 이름이 환영 메시지에 표시되어 개인화된 안내 메시지를 제공합니다.
  * 약관/개인정보 동의 페이지에서 JWT 토큰을 활용해 사용자 정보를 자동으로 불러오고, 동의 시 해당 정보를 저장한 뒤 설문 페이지로 이동합니다.

* **버그 수정**
  * 설문 페이지에서 사용자 정보가 올바르게 불러와지도록 데이터 초기화 방식을 개선했습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->