### PR TITLE
Fix/admin qa

### DIFF
--- a/public/administrate/css/food-management/admin-food.css
+++ b/public/administrate/css/food-management/admin-food.css
@@ -111,6 +111,11 @@
     min-width: 180px;    
 }
 
+#adminFoodTable .td-representative-name {
+    min-width: 150px;
+    max-width: 150px;    
+}
+
 #adminFoodTable .td-calorie {
     min-width: 90px;
     max-width: 90px;    

--- a/public/administrate/js/food-management/adminFoodTable.js
+++ b/public/administrate/js/food-management/adminFoodTable.js
@@ -44,7 +44,7 @@ export function renderTable(containerId, bodyId) {
                     <th class="th-food-name">식품명</th>
                     <th class="th-food-code">식품코드</th>
                     <th class="th-source">데이터출처</th>   
-                    <th class="th-main-food-name">대표식품명</th>
+                    <th class="th-representative-name">대표식품명</th>
                     <th class="th-calorie">칼로리</th>
                     <th class="th-carbo">탄수화물</th>
                     <th class="th-protein">단백질</th>

--- a/public/administrate/js/food-management/adminFoodTable.js
+++ b/public/administrate/js/food-management/adminFoodTable.js
@@ -19,7 +19,7 @@ function createRows({ id, foodName, foodCode, representativeName, kcal, carbo, p
                         foodType === 'CUSTOM' ? '유저 등록' : ''}
                 </div>
             </td>
-            <td class="td-main-food-name">${representativeName}</td>
+            <td class="td-representative-name">${representativeName ? representativeName : '-'}</td>
             <td class="td-calorie">${kcal}kcal</td>
             <td class="td-carbo">${carbo}g</td>
             <td class="td-protein">${protein}g</td>


### PR DESCRIPTION
[[Fix] 테이블 대표음식명 크기고정, 없는경우 - 로 보이게 수정](https://github.com/DA-ALL/HowToEat_Frontend/commit/e6835d4b8a5f63d149123577e4dd8262c0f07609) https://github.com/DA-ALL/HowToEat_Frontend/issues/99

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * 대표 식품명 셀의 너비가 고정되어 표 레이아웃이 개선되었습니다.

* **Refactor**
  * 대표 식품명 열의 클래스명이 변경되고, 값이 없을 경우 하이픈("-")이 표시되도록 수정되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->